### PR TITLE
add authz to SetOrderEndBlockers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -526,6 +526,7 @@ func New(
 		minttypes.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
+		authz.ModuleName,
 		feegrant.ModuleName,
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,


### PR DESCRIPTION
Fixed a bug from #8. Manually tested the functionality of cosmwasm and the authz module. Also tested the upgrade to this version on a single-node network. All tests passed successfully!